### PR TITLE
Change the indices of the vanilla and boxed correlationsum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.1
+- Change the indices of the outer sum of the correlationsum to i = 1 to N and adapt normalisations.
+
 # 1.7
 
 - Update `extremevaltheory_gpdfit_pvalues` to calculate further the NRMSE of the GPD fits.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FractalDimensions"
 uuid = "4665ce21-e117-4649-aed8-08bbe5ccbead"
 authors = ["George Datseris <datseris.george@gmail.com>"]
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 ComplexityMeasures = "ab4b797d-85ee-42ba-b621-05d793b346a2"

--- a/src/corrsum_based/correlationsum_boxassisted.jl
+++ b/src/corrsum_based/correlationsum_boxassisted.jl
@@ -282,7 +282,7 @@ function boxed_correlationsum_q(boxes, contents, X, εs, q; norm = Euclidean(), 
         ProgressMeter.next!(progress)
     end
     C = .+(Css...,)
-    return clamp.((C ./ ((N - 2w) * (N - 2w - 1) ^ (q-1))), 0, Inf) .^ (1 / (q-1))
+    return clamp.(C, 0, Inf) .^ (1 / (q-1))
 end
 
 function find_neighborboxes_q(index, boxes, contents)
@@ -303,9 +303,8 @@ function inner_correlationsum_q!(
     )
     N, Nε = length(data), length(εs)
     for i in idxs_box
-        # Check that this index is not within Theiler window of the boundary
-        # This step is neccessary for easy normalisation.
-        (i < w + 1 || i > N - w) && continue
+        # The normalisation is index dependent since the number of total points considered varies.
+        normalisation = (N * (max(N - w, i) - min(w + 1, i))^(q - 1))
         C_current .= 0
         x = data[i]
         for j in idxs_neigh
@@ -321,7 +320,7 @@ function inner_correlationsum_q!(
 		        end
 		    end
         end
-        Cs .+= C_current .^ (q-1)
+        Cs .+= C_current .^ (q-1) ./ normalisation
     end
     return Cs
 end


### PR DESCRIPTION
Changed the indices of the outer sum of the correlationsum to run from ``i = 1`` to ``N`` instead of ``i = w + 1`` to ``N-w``. The normalisation has been adapted accordingly. 

In all uses of the function for testing or plotting I haven't noticed any considerable slowdown.

Whether this is an improvement in precision is unclear, the fractal dimension the two variants find, differs a bit for small number of points (N < 1000) which is expected when 20 out of 100 or 200 points are discarded:
![comp_old_new](https://github.com/JuliaDynamics/FractalDimensions.jl/assets/11183188/ad352f4d-7293-4dcb-93c0-7302c68a98d1)

Note: This change only changes the more general q-order correlation not the optimised version for `q = 2` hence I chose `q = 1.99`